### PR TITLE
Test integration with ICU (Unicode) lib

### DIFF
--- a/src/main/java/net/zetetic/tests/TestSuiteRunner.java
+++ b/src/main/java/net/zetetic/tests/TestSuiteRunner.java
@@ -73,6 +73,7 @@ public class TestSuiteRunner extends AsyncTask<ResultNotifier, TestResult, Void>
         tests.add(new RawRekeyTest());
         //tests.add(new MultiThreadReadWriteTest());
         tests.add(new NestedTransactionsTest());
+        tests.add(new UnicodeTest());
         return tests;
     }
 }

--- a/src/main/java/net/zetetic/tests/UnicodeTest.java
+++ b/src/main/java/net/zetetic/tests/UnicodeTest.java
@@ -1,0 +1,25 @@
+package net.zetetic.tests;
+
+import android.database.Cursor;
+import net.sqlcipher.database.SQLiteDatabase;
+
+public class UnicodeTest extends SQLCipherTest {
+    @Override
+    public boolean execute(SQLiteDatabase database) {
+
+        String expected = "КАКОЙ-ТО КИРИЛЛИЧЕСКИЙ ТЕКСТ"; // SOME Cyrillic TEXT
+        String actual = "";
+        Cursor result = database.rawQuery("select UPPER('Какой-то кириллический текст') as u1", new String[]{});
+        if(result != null){
+            result.moveToFirst();
+            actual = result.getString(0);
+            result.close();
+        }
+        return actual.equals(expected);
+    }
+
+    @Override
+    public String getName() {
+        return "Unicode (ICU) Test";
+    }
+}


### PR DESCRIPTION
This was also a problem with the Android sqlite library in the past. This test will fail unless we fix `external/Android.mk` (which I will push next).
