### PR TITLE
Test crash scenario due to Unicode emoji characters

### DIFF
--- a/src/main/java/net/zetetic/tests/UnicodeTest.java
+++ b/src/main/java/net/zetetic/tests/UnicodeTest.java
@@ -2,20 +2,32 @@ package net.zetetic.tests;
 
 import android.database.Cursor;
 import net.sqlcipher.database.SQLiteDatabase;
+import net.sqlcipher.database.SQLiteStatement;
 
 public class UnicodeTest extends SQLCipherTest {
     @Override
     public boolean execute(SQLiteDatabase database) {
-
         String expected = "КАКОЙ-ТО КИРИЛЛИЧЕСКИЙ ТЕКСТ"; // SOME Cyrillic TEXT
         String actual = "";
+
         Cursor result = database.rawQuery("select UPPER('Какой-то кириллический текст') as u1", new String[]{});
-        if(result != null){
+        if (result != null) {
             result.moveToFirst();
             actual = result.getString(0);
             result.close();
         }
-        return actual.equals(expected);
+        if (!actual.equals(expected)) return false;
+
+        if (android.os.Build.VERSION.SDK_INT >= 23) { // Android M
+            // This will crash on Android releases 1.X-5.X due the following Android bug:
+            // https://code.google.com/p/android/issues/detail?id=81341
+            SQLiteStatement st = database.compileStatement("SELECT '\uD83D\uDE03'"); // SMILING FACE (MOUTH OPEN)
+            String res = st.simpleQueryForString();
+            if (!res.equals("\uD83D\uDE03")) return false;
+        }
+
+        // all ok:
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Add test to UnicodeTest.java with the crash scenario due to [Android bug 81341](https://code.google.com/p/android/issues/detail?id=81341) on emoji characters, as reported in sqlcipher/android-database-sqlcipher#199. Following the link from [Android bug 81341](https://code.google.com/p/android/issues/detail?id=81341) to https://android-review.googlesource.com/#/c/130121/

Note that the crash scenario is guarded by `if (android.os.Build.VERSION.SDK_INT >= 23)` which should run the test on Android M/6.X or later, may crash on older M pre-releases. I did not try running this on Android M/6.X myself.