### PR TITLE
Add test for Cursor#copyStringToBuffer.

### DIFF
--- a/src/main/java/net/zetetic/tests/CopyStringToBufferTest.java
+++ b/src/main/java/net/zetetic/tests/CopyStringToBufferTest.java
@@ -1,0 +1,30 @@
+package net.zetetic.tests;
+
+import android.database.CharArrayBuffer;
+
+import net.sqlcipher.Cursor;
+import net.sqlcipher.database.SQLiteDatabase;
+
+public class CopyStringToBufferTest extends SQLCipherTest {
+
+    private CharArrayBuffer charArrayBuffer = new CharArrayBuffer(128);
+
+    @Override
+    public boolean execute(SQLiteDatabase database) {
+        database.execSQL("create table t1(a TEXT, b TEXT);");
+        database.execSQL("insert into t1(a,b) values(500, 500);");
+        Cursor cursor = database.rawQuery("select * from t1;", new String[]{});
+        if(cursor != null){
+            cursor.moveToFirst();
+            cursor.copyStringToBuffer(0, charArrayBuffer);
+            String actualValue = new String(charArrayBuffer.data, 0, charArrayBuffer.sizeCopied);
+            return "500".equals(actualValue);
+        }
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "Copy String To Buffer";
+    }
+}

--- a/src/main/java/net/zetetic/tests/TestSuiteRunner.java
+++ b/src/main/java/net/zetetic/tests/TestSuiteRunner.java
@@ -101,6 +101,7 @@ public class TestSuiteRunner extends AsyncTask<ResultNotifier, TestResult, Void>
         tests.add(new ChangePasswordTest());
         tests.add(new ReadableWritableInvalidPasswordTest());
         tests.add(new InvalidOpenArgumentTest());
+        tests.add(new CopyStringToBufferTest());
 
         return tests;
     }


### PR DESCRIPTION
This test fails for SQLcipher 3.5.1 and 3.5.3.
