### PR TITLE
Basic error message tests with bug reproduction

### DIFF
--- a/src/main/java/net/zetetic/tests/CompileStatementSyntaxErrorMessageTest.java
+++ b/src/main/java/net/zetetic/tests/CompileStatementSyntaxErrorMessageTest.java
@@ -1,24 +1,27 @@
 package net.zetetic.tests;
 
+import android.database.Cursor;
+
 import net.sqlcipher.database.SQLiteDatabase;
+import net.sqlcipher.database.SQLiteStatement;
 import net.sqlcipher.database.SQLiteException;
 
 import net.zetetic.ZeteticApplication;
 
 import android.util.Log;
 
-public class RawExecSQLExceptionTest extends SQLCipherTest {
+public class CompileStatementSyntaxErrorMessageTest extends SQLCipherTest {
 
     @Override
     public boolean execute(SQLiteDatabase database) {
-
         try {
-            database.rawExecSQL("select foo from bar");
+            SQLiteStatement ignored = database.compileStatement("INSERT INTO mytable (mydata) VALUES");
         } catch (SQLiteException e) {
             Log.v(ZeteticApplication.TAG, "EXPECTED RESULT: DID throw SQLiteException", e);
             String message = e.getMessage();
             setMessage(message);
-            if (!message.matches("no such table: bar")) {
+            // TBD missing error code etc.
+            if (!message.matches("near \"VALUES\": syntax error: .*\\, while compiling: INSERT INTO mytable \\(mydata\\) VALUES")) {
                 Log.e(ZeteticApplication.TAG, "NOT EXPECTED: INCORRECT exception message: " + message);
                 return false;
             }
@@ -33,6 +36,6 @@ public class RawExecSQLExceptionTest extends SQLCipherTest {
 
     @Override
     public String getName() {
-        return "rawExecSQL Exception Test";
+        return "Compile statement syntax error message Test";
     }
 }

--- a/src/main/java/net/zetetic/tests/ExecuteInsertConstraintErrorMessageTest.java
+++ b/src/main/java/net/zetetic/tests/ExecuteInsertConstraintErrorMessageTest.java
@@ -1,0 +1,43 @@
+package net.zetetic.tests;
+
+import android.database.Cursor;
+
+import net.sqlcipher.database.SQLiteDatabase;
+import net.sqlcipher.database.SQLiteStatement;
+import net.sqlcipher.database.SQLiteConstraintException;
+
+import net.zetetic.ZeteticApplication;
+
+import android.util.Log;
+
+public class ExecuteInsertConstraintErrorMessageTest extends SQLCipherTest {
+
+    @Override
+    public boolean execute(SQLiteDatabase database) {
+        database.execSQL("CREATE TABLE tt(a UNIQUE, b)");
+        database.execSQL("INSERT INTO tt VALUES (101, 'Alice')");
+        try {
+            SQLiteStatement insertStatement = database.compileStatement("INSERT INTO tt VALUES (101, 'Betty')");
+            long ignored = insertStatement.executeInsert();
+        } catch (SQLiteConstraintException e) {
+            Log.v(ZeteticApplication.TAG, "EXPECTED RESULT: DID throw SQLiteConstraintException", e);
+            String message = e.getMessage();
+            setMessage(message);
+            if (!message.matches("error code 19: UNIQUE constraint failed: tt\\.a")) {
+                Log.e(ZeteticApplication.TAG, "NOT EXPECTED: INCORRECT exception message: " + message);
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            Log.e(ZeteticApplication.TAG, "NOT EXPECTED: DID throw other exception", e);
+            return false;
+        }
+
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "Execute insert constraint error message Test";
+    }
+}

--- a/src/main/java/net/zetetic/tests/RawQueryNoSuchFunctionErrorMessageTest.java
+++ b/src/main/java/net/zetetic/tests/RawQueryNoSuchFunctionErrorMessageTest.java
@@ -1,5 +1,7 @@
 package net.zetetic.tests;
 
+import android.database.Cursor;
+
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteException;
 
@@ -7,18 +9,18 @@ import net.zetetic.ZeteticApplication;
 
 import android.util.Log;
 
-public class RawExecSQLExceptionTest extends SQLCipherTest {
+public class RawQueryNoSuchFunctionErrorMessageTest extends SQLCipherTest {
 
     @Override
     public boolean execute(SQLiteDatabase database) {
-
         try {
-            database.rawExecSQL("select foo from bar");
+            Cursor ignored = database.rawQuery("SELECT UPER('Test')", null);
         } catch (SQLiteException e) {
             Log.v(ZeteticApplication.TAG, "EXPECTED RESULT: DID throw SQLiteException", e);
             String message = e.getMessage();
             setMessage(message);
-            if (!message.matches("no such table: bar")) {
+            // TBD missing error code etc.
+            if (!message.matches("no such function: UPER: .*\\, while compiling: SELECT UPER\\('Test'\\)")) {
                 Log.e(ZeteticApplication.TAG, "NOT EXPECTED: INCORRECT exception message: " + message);
                 return false;
             }
@@ -33,6 +35,6 @@ public class RawExecSQLExceptionTest extends SQLCipherTest {
 
     @Override
     public String getName() {
-        return "rawExecSQL Exception Test";
+        return "rawQuery no such function error message Test";
     }
 }

--- a/src/main/java/net/zetetic/tests/RawQueryNonsenseStatementErrorMessageTest.java
+++ b/src/main/java/net/zetetic/tests/RawQueryNonsenseStatementErrorMessageTest.java
@@ -1,5 +1,7 @@
 package net.zetetic.tests;
 
+import android.database.Cursor;
+
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteException;
 
@@ -7,18 +9,20 @@ import net.zetetic.ZeteticApplication;
 
 import android.util.Log;
 
-public class RawExecSQLExceptionTest extends SQLCipherTest {
+import java.util.regex.Pattern;
+
+public class RawQueryNonsenseStatementErrorMessageTest extends SQLCipherTest {
 
     @Override
     public boolean execute(SQLiteDatabase database) {
-
         try {
-            database.rawExecSQL("select foo from bar");
+            Cursor ignored = database.rawQuery("101", null);
         } catch (SQLiteException e) {
             Log.v(ZeteticApplication.TAG, "EXPECTED RESULT: DID throw SQLiteException", e);
             String message = e.getMessage();
             setMessage(message);
-            if (!message.matches("no such table: bar")) {
+            // TBD missing error code etc.
+            if (!message.matches("near \"101\": syntax error: .*\\, while compiling: 101")) {
                 Log.e(ZeteticApplication.TAG, "NOT EXPECTED: INCORRECT exception message: " + message);
                 return false;
             }
@@ -33,6 +37,6 @@ public class RawExecSQLExceptionTest extends SQLCipherTest {
 
     @Override
     public String getName() {
-        return "rawExecSQL Exception Test";
+        return "rawQuery nonsense statement error message Test";
     }
 }

--- a/src/main/java/net/zetetic/tests/RawQuerySyntaxErrorMessageTest.java
+++ b/src/main/java/net/zetetic/tests/RawQuerySyntaxErrorMessageTest.java
@@ -1,5 +1,7 @@
 package net.zetetic.tests;
 
+import android.database.Cursor;
+
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteException;
 
@@ -7,18 +9,18 @@ import net.zetetic.ZeteticApplication;
 
 import android.util.Log;
 
-public class RawExecSQLExceptionTest extends SQLCipherTest {
+public class RawQuerySyntaxErrorMessageTest extends SQLCipherTest {
 
     @Override
     public boolean execute(SQLiteDatabase database) {
-
         try {
-            database.rawExecSQL("select foo from bar");
+            Cursor ignored = database.rawQuery("SLCT 1", null);
         } catch (SQLiteException e) {
             Log.v(ZeteticApplication.TAG, "EXPECTED RESULT: DID throw SQLiteException", e);
             String message = e.getMessage();
             setMessage(message);
-            if (!message.matches("no such table: bar")) {
+            // TBD missing error code etc.
+            if (!message.matches("near \"SLCT\": syntax error: .*\\, while compiling: SLCT 1")) {
                 Log.e(ZeteticApplication.TAG, "NOT EXPECTED: INCORRECT exception message: " + message);
                 return false;
             }
@@ -33,6 +35,6 @@ public class RawExecSQLExceptionTest extends SQLCipherTest {
 
     @Override
     public String getName() {
-        return "rawExecSQL Exception Test";
+        return "rawQuery syntax error message Test";
     }
 }

--- a/src/main/java/net/zetetic/tests/TestSuiteRunner.java
+++ b/src/main/java/net/zetetic/tests/TestSuiteRunner.java
@@ -112,6 +112,11 @@ public class TestSuiteRunner extends AsyncTask<ResultNotifier, TestResult, Void>
         tests.add(new VerifyCipherProviderTest());
         tests.add(new VerifyCipherProviderVersionTest());
         tests.add(new AES256GCMCipherTest());
+        tests.add(new RawQuerySyntaxErrorMessageTest());
+        tests.add(new RawQueryNonsenseStatementErrorMessageTest());
+        tests.add(new RawQueryNoSuchFunctionErrorMessageTest());
+        tests.add(new CompileStatementSyntaxErrorMessageTest());
+        tests.add(new ExecuteInsertConstraintErrorMessageTest());
         return tests;
     }
 }


### PR DESCRIPTION
These tests reproduce ~~a couple~~ _an_ issue~~s~~ I discovered from testing my Cordova plugin:
- ~~In case of nonsense singe-word SQL statements such as "101" or "false" SQLCipher for Android throws StringIndexOutOfBoundsException with a nonsense error message.~~ _no longer an issue in 3.5.5 release_
- While newer versions of the AOSP SQLite database classes include the SQLite error code in the error messages SQLCipher for Android only includes the error code in very specific cases such as a constraint violation.

~~For the Cordova plugin I will probably just add a quick fix to deal with the nonsense SQL case.~~ _(no longer needed)_