### PR TITLE
External storage error

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,6 +3,8 @@
           package="net.zetetic" android:versionCode="1" android:versionName="1.0-SNAPSHOT">
     <uses-sdk android:minSdkVersion="7" android:targetSdkVersion="23"/>
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application android:icon="@drawable/icon"
                  android:debuggable="true"
                  android:label="@string/app_name"

--- a/src/main/java/net/zetetic/tests/ExternalStorageTest.java
+++ b/src/main/java/net/zetetic/tests/ExternalStorageTest.java
@@ -1,0 +1,55 @@
+package net.zetetic.tests;
+
+import net.sqlcipher.database.SQLiteDatabase;
+
+import android.database.Cursor;
+import android.os.Environment;
+import android.util.Log;
+
+import java.io.File;
+
+public class ExternalStorageTest extends SQLCipherTest {
+
+    private SQLiteDatabase database;
+    private File databasePath;
+
+    @Override
+    protected void setUp() {
+        super.setUp();
+        databasePath = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/test/encrypt_coresuite.db");
+        databasePath.getParentFile().mkdirs();
+        databasePath.mkdirs();
+        databasePath.delete();
+        Log.i(TAG, "Before createDatabase");
+        database = createDatabase(databasePath);
+        Log.i(TAG, "after createDatabase");
+    }
+
+    @Override
+    protected void tearDown(SQLiteDatabase ignored) {
+        super.tearDown(ignored);
+        SQLiteDatabase.releaseMemory();
+        this.database.close();
+        if (databasePath != null && databasePath.exists()) {
+            databasePath.delete();
+        }
+    }
+
+    @Override
+    public boolean execute(SQLiteDatabase ignored) {
+        try {
+            database.execSQL("create table t1(a, b)");
+            database.execSQL("insert into t1(a, b) values(?, ?)", new Object[]{"one for the money", "two for the show"});
+            Cursor c = database.rawQuery("select * from t1;", null);
+            return c.getCount() == 1;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "Text external path";
+    }
+}

--- a/src/main/java/net/zetetic/tests/TestSuiteRunner.java
+++ b/src/main/java/net/zetetic/tests/TestSuiteRunner.java
@@ -47,6 +47,7 @@ public class TestSuiteRunner extends AsyncTask<ResultNotifier, TestResult, Void>
 
     private List<SQLCipherTest> getTestsToRun(){
         List<SQLCipherTest> tests = new ArrayList<SQLCipherTest>();
+        tests.add(new ExternalStorageTest());
         tests.add(new TimeQueryExecutionTest());
         tests.add(new PragmaCipherVersionTest());
         tests.add(new UnicodeTest());


### PR DESCRIPTION
I've added a test when the db is on external storage. The problem that appears is net.sqlcipher.database.SQLiteException: attempt to write a readonly database (https://github.com/sqlcipher/android-database-sqlcipher/issues/161). 
This issue will only reproduce if you use a x86_64 system image.