### PR TITLE
Gradle build updates from Android Studio 4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
       google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.6.0'
+    classpath 'com.android.tools.build:gradle:4.0.0'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 25 09:47:07 CST 2020
+#Wed Jun 03 16:06:30 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
Android Studio 4.0 offered to make these updates. With these updates, I was able to build and run from both Android Studio and the command line.

To run from the command line, I did upgrade my local gradle to 6.5 (not sure if this makes any difference or not) then installed with the following command:

```
./gradlew installDebug
```

as described here: https://developer.android.com/studio/build/building-cmdline#DebugMode