### PR TITLE
update support tests for SQLCipher 4.4.0

### DIFF
--- a/app/src/main/java/net/zetetic/tests/JavaClientLibraryVersionTest.java
+++ b/app/src/main/java/net/zetetic/tests/JavaClientLibraryVersionTest.java
@@ -4,12 +4,12 @@ import net.sqlcipher.database.SQLiteDatabase;
 
 public class JavaClientLibraryVersionTest extends SQLCipherTest {
 
-  String expectedClientLibraryVersion = "4.4.0";
+  private final String EXPECTED_SQLCIPHER_ANDROID_VERSION = "4.4.0";
 
   @Override
   public boolean execute(SQLiteDatabase database) {
     setMessage(String.format("Report:%s", SQLiteDatabase.SQLCIPHER_ANDROID_VERSION));
-    return SQLiteDatabase.SQLCIPHER_ANDROID_VERSION.equals(expectedClientLibraryVersion);
+    return SQLiteDatabase.SQLCIPHER_ANDROID_VERSION.equals(EXPECTED_SQLCIPHER_ANDROID_VERSION);
   }
 
   @Override

--- a/app/src/main/java/net/zetetic/tests/support/JavaClientLibraryVersionTest.java
+++ b/app/src/main/java/net/zetetic/tests/support/JavaClientLibraryVersionTest.java
@@ -5,12 +5,12 @@ import net.zetetic.tests.SQLCipherTest;
 
 public class JavaClientLibraryVersionTest extends SupportTest {
 
-  String expectedClientLibraryVersion = "4.3.0";
+  private final String EXPECTED_SQLCIPHER_ANDROID_VERSION = "4.4.0";
 
   @Override
   public boolean execute(SQLiteDatabase database) {
     setMessage(String.format("Report:%s", SQLiteDatabase.SQLCIPHER_ANDROID_VERSION));
-    return SQLiteDatabase.SQLCIPHER_ANDROID_VERSION.equals(expectedClientLibraryVersion);
+    return SQLiteDatabase.SQLCIPHER_ANDROID_VERSION.equals(EXPECTED_SQLCIPHER_ANDROID_VERSION);
   }
 
   @Override

--- a/app/src/main/java/net/zetetic/tests/support/PragmaCipherVersionTest.java
+++ b/app/src/main/java/net/zetetic/tests/support/PragmaCipherVersionTest.java
@@ -7,7 +7,7 @@ import net.zetetic.tests.SQLCipherTest;
 
 public class PragmaCipherVersionTest extends SupportTest {
 
-    private final String CURRENT_CIPHER_VERSION = "4.3.0";
+    private final String CURRENT_CIPHER_VERSION = "4.4.0";
 
     @Override
     public boolean execute(SQLiteDatabase database) {


### PR DESCRIPTION
(and apply some other minor cleanup)

Unfortunately I missed these when I raised the updates in PR #36.

As a side point, I wonder if we could find a way to have some of the test cases run with and without the changes for the support tests. I think this should be easier to maintain and less prone to missed updates like this one.