### PR TITLE
SQLCompileStatement crash DEMO

### DIFF
--- a/app/src/main/java/net/zetetic/tests/SQLComileStatementFinalizeTest.java
+++ b/app/src/main/java/net/zetetic/tests/SQLComileStatementFinalizeTest.java
@@ -1,0 +1,83 @@
+package net.zetetic.tests;
+
+import net.sqlcipher.database.SQLiteDatabase;
+import net.sqlcipher.database.SQLiteStatement;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class SQLComileStatementFinalizeTest extends SQLCipherTest {
+
+    private final int count = 2;
+
+    @Override
+    public boolean execute(final SQLiteDatabase database) {
+
+        final CountDownLatch latchMain = new CountDownLatch(1);
+        final CountDownLatch latchTransaction = new CountDownLatch(1);
+        final CountDownLatch latchSQLRelease = new CountDownLatch(1);
+
+        database.execSQL("CREATE TABLE TestTable(text_value TEXT);");
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+
+                for (int i = 0; i < count; i++) {
+                    SQLiteStatement statement = database.compileStatement("DELETE FROM TestTable");
+                    statement.executeUpdateDelete();
+                }
+
+                latchSQLRelease.countDown();
+                try {
+                    latchTransaction.await();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }).start();
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    latchSQLRelease.await();
+
+                    database.beginTransaction();
+
+                    latchTransaction.countDown();
+
+                    long start = System.currentTimeMillis();
+                    while (System.currentTimeMillis() < start + TimeUnit.SECONDS.toMillis(40)) {
+                        new Object();
+                        System.gc();
+                    }
+                    database.setTransactionSuccessful();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                } finally {
+                    database.endTransaction();
+                }
+
+                latchMain.countDown();
+            }
+        }).start();
+
+
+        try {
+            latchMain.await();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "Finalize SQLComileStatement causes crash on API 24-25";
+    }
+
+
+}

--- a/app/src/main/java/net/zetetic/tests/SQLCompileStatementFinalizeTest.java
+++ b/app/src/main/java/net/zetetic/tests/SQLCompileStatementFinalizeTest.java
@@ -6,7 +6,7 @@ import net.sqlcipher.database.SQLiteStatement;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class SQLComileStatementFinalizeTest extends SQLCipherTest {
+public class SQLCompileStatementFinalizeTest extends SQLCipherTest {
 
     private final int count = 2;
 
@@ -29,6 +29,7 @@ public class SQLComileStatementFinalizeTest extends SQLCipherTest {
                 }
 
                 latchSQLRelease.countDown();
+
                 try {
                     latchTransaction.await();
                 } catch (InterruptedException e) {

--- a/app/src/main/java/net/zetetic/tests/TestSuiteRunner.java
+++ b/app/src/main/java/net/zetetic/tests/TestSuiteRunner.java
@@ -8,7 +8,6 @@ import android.view.WindowManager;
 
 import net.sqlcipher.CursorWindow;
 import net.sqlcipher.CursorWindowAllocation;
-import net.sqlcipher.database.SQLiteDatabase;
 import net.zetetic.ZeteticApplication;
 
 import java.util.ArrayList;
@@ -70,7 +69,7 @@ public class TestSuiteRunner extends AsyncTask<ResultNotifier, TestResult, Void>
   private List<SQLCipherTest> getTestsToRun() {
     List<SQLCipherTest> tests = new ArrayList<>();
 
-    tests.add(new SQLComileStatementFinalizeTest());
+    tests.add(new SQLCompileStatementFinalizeTest());
     tests.add(new SummingStepTest());
 
     tests.add(new JsonCastTest());

--- a/app/src/main/java/net/zetetic/tests/TestSuiteRunner.java
+++ b/app/src/main/java/net/zetetic/tests/TestSuiteRunner.java
@@ -69,7 +69,8 @@ public class TestSuiteRunner extends AsyncTask<ResultNotifier, TestResult, Void>
   private List<SQLCipherTest> getTestsToRun() {
     List<SQLCipherTest> tests = new ArrayList<>();
 
-    tests.add(new SQLCompileStatementFinalizeTest());
+    tests.add(new SQLCompileStatementFinalizeTest(false));
+    tests.add(new SQLCompileStatementFinalizeTest(true));
     tests.add(new SummingStepTest());
 
     tests.add(new JsonCastTest());

--- a/app/src/main/java/net/zetetic/tests/TestSuiteRunner.java
+++ b/app/src/main/java/net/zetetic/tests/TestSuiteRunner.java
@@ -70,6 +70,7 @@ public class TestSuiteRunner extends AsyncTask<ResultNotifier, TestResult, Void>
   private List<SQLCipherTest> getTestsToRun() {
     List<SQLCipherTest> tests = new ArrayList<>();
 
+    tests.add(new SQLComileStatementFinalizeTest());
     tests.add(new SummingStepTest());
 
     tests.add(new JsonCastTest());


### PR DESCRIPTION
Added test to showcase crash on Android API 24-25 caused by `java.util.concurrent.TimeoutException: net.sqlcipher.database.SQLiteCompiledSql.finalize() timed out after 10 seconds`
Run the test and wait ~30 seconds.

Warning:
This test will crash the app. 
I don't see a clean way of integrating this as an Action in the app. Instead, I suggest doing an Instrumented Android test 

Original issue:
https://github.com/sqlcipher/android-database-sqlcipher/issues/537

This test repeats Room behavior when it generates code for delete method:
```
  @Override
  public Object deleteXXX(final List<Long> localIds,
      final Continuation<? super Integer> p1) {
    return CoroutinesRoom.execute(__db, true, new Callable<Integer>() {
      @Override
      public Integer call() throws Exception {
        StringBuilder _stringBuilder = StringUtil.newStringBuilder();
        _stringBuilder.append("DELETE FROM XXX WHERE local_id IN (");
        final int _inputSize = localIds.size();
        StringUtil.appendPlaceholders(_stringBuilder, _inputSize);
        _stringBuilder.append(")");
        final String _sql = _stringBuilder.toString();
        final SupportSQLiteStatement _stmt = __db.compileStatement(_sql);
        int _argIndex = 1;
        for (Long _item : localIds) {
          if (_item == null) {
            _stmt.bindNull(_argIndex);
          } else {
            _stmt.bindLong(_argIndex, _item);
          }
          _argIndex ++;
        }
        __db.beginTransaction();
        try {
          final java.lang.Integer _result = _stmt.executeUpdateDelete();
          __db.setTransactionSuccessful();
          return _result;
        } finally {
          __db.endTransaction();
        }
      }
    }, p1);
  }
```